### PR TITLE
Various fixes and updates

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -55,7 +55,7 @@ class FFVCDWorld(World):
     
     
     topology_present = False
-    data_version = 0
+    data_version = 1
     base_id = 776000
     
     item_name_to_id = {name: data.id for name, data in item_table.items()}

--- a/locations.py
+++ b/locations.py
@@ -40,7 +40,7 @@ class FFVCDLocation(Location):
         # only allow karnak to place this seed's items
         # disallow lone wolf/under bal castle related checks for some weird progression problems
         if location_data.area in ["Kuzar", "Mua", "Karnak"] or location_data.address in ['C0FB38', 'C0FB3A']:
-            add_item_rule(self, lambda item: item.player != self.player or 'Item' not in item.groups)
+            add_item_rule(self, lambda item: item.player == self.player)
 
 
 
@@ -51,7 +51,7 @@ class FFVCDLocation(Location):
         # they can be other players' items too
         # they just can't be this world's own ITEMS 
         if "fire crystal" in location_data.name.lower():
-            add_item_rule(self, lambda item: not ('Item' in item.groups))
+            add_item_rule(self, lambda item: item.player != self.player or 'Item' not in item.groups)
 
             
 

--- a/locations.py
+++ b/locations.py
@@ -40,7 +40,7 @@ class FFVCDLocation(Location):
         # only allow karnak to place this seed's items
         # disallow lone wolf/under bal castle related checks for some weird progression problems
         if location_data.area in ["Kuzar", "Mua", "Karnak"] or location_data.address in ['C0FB38', 'C0FB3A']:
-            add_item_rule(self, lambda item: item.player == self.player)
+            add_item_rule(self, lambda item: item.player != self.player or 'Item' not in item.groups)
 
 
 

--- a/options.py
+++ b/options.py
@@ -1,4 +1,4 @@
-from Options import Toggle, DefaultOnToggle, OptionSet
+from Options import Toggle, DefaultOnToggle, Range
 
 
 class JobPalettes(Toggle):
@@ -19,18 +19,16 @@ class RemoveFlashes(DefaultOnToggle):
     """
     display_name = "Apply flash removal"
 
-class WorldLock(OptionSet):
+class WorldLock(Range):
     """Determines how many worlds are available from the start.
     1: The first world is available. Adamantite unlocks World 2. Defeating Exdeath in World 2 unlocks World 3 via Anti Barrier and Bracelet.
     2: Worlds 1 and 2 are available. Defeating Exdeath in World 2 unlocks World 3 via Anti Barrier and Bracelet.
     3: All worlds are available immediately.    
     """
     display_name = "World Lock"
-    valid_keys = {
-        "1",
-        "2",
-        "3",
-    }
+    range_start = 1
+    range_end = 3
+    default = 3
 
 
 ffvcd_options = {

--- a/rom.py
+++ b/rom.py
@@ -8,7 +8,7 @@ ROM_PLAYER_LIMIT = 65535
 
 import hashlib
 import os
-
+from settings import get_settings
 
 
 
@@ -127,10 +127,10 @@ class FFVCDDeltaPatch(APDeltaPatch):
         return get_base_rom_bytes()
 
 
-def get_base_rom_bytes(file_name: str = "") -> bytes:
+def get_base_rom_bytes() -> bytes:
     base_rom_bytes = getattr(get_base_rom_bytes, "base_rom_bytes", None)
     if not base_rom_bytes:
-        file_name = get_base_rom_path(file_name)
+        file_name = get_base_rom_path()
         base_rom_bytes = bytes(read_snes_rom(open(file_name, "rb")))
 
         basemd5 = hashlib.md5()
@@ -141,14 +141,12 @@ def get_base_rom_bytes(file_name: str = "") -> bytes:
         get_base_rom_bytes.base_rom_bytes = base_rom_bytes
     return base_rom_bytes
 
-def get_base_rom_path(file_name: str = "") -> str:
-    options = Utils.get_options()
-    if not file_name:
-        file_name = options["ffvcd_options"]["rom_file"]
+
+def get_base_rom_path():
+    file_name = get_settings()["ffvcd_options"]["rom_file"]
     if not os.path.exists(file_name):
         file_name = Utils.user_path(file_name)
     return file_name
-
 
 
 


### PR DESCRIPTION
- world_lock is now a Range option.
- Patch files are generated instead of rom files.
- Settings class was created and generating or opening the patch file should prompt users to locate their rom if they do not have it set up in host.yaml, so it should no longer need to be added manually
- Edits an item rule to allow items from other players before evaluating Item.groups, which may not exist for items for other games.